### PR TITLE
conditionally restore depth ordering of relations

### DIFF
--- a/pages/mock-graph-data/freeform.html
+++ b/pages/mock-graph-data/freeform.html
@@ -26,6 +26,7 @@
       if(to<0) to = g.addNode(type,{name})
       const cap = word => word[0].toUpperCase() + word.slice(1)
       g.addRel(cap(words[0]),here,to,{})
+      if(words[2] == 'which') here = to
     }
   }
   window.result.innerText = JSON.stringify(g.tally(),null,2)


### PR DESCRIPTION
## Freeform.html

Having misunderstood how freeform.html ordered nodes and relations I mistakenly believed that "here" stayed at a node and accumulated relation until specifically moved. We can say that I assumed a breadth first order when it had been coded as a depth first by advancing "here" as every relation is recorded. I incorrectly removed this feature with a recent commit and restore it here.

This commit creates a new keyword, which, that can be present in the third word position on a relation line. From the dictionary:
> "which" is used referring to something previously mentioned when introducing a clause giving further information.

I have updated the original freeform graph to use "which" as appropriate.
```
Person:Consumer
consumes Consumable:VegOil which
depletes Resource:Health which
increases Disease:HeartStrokeObesity

Resource:Health
increases Economy:LostLifeWages

Consumable:VegOil
demands Person:Producer which
consumes Resource:Forest which
depletes Resource:Diversity

Resource:Forest
increases Resource:CO2 which
increases Resource:Temperature which
increases Calamities:FireFloodWar
```
We examined three graphs:
- a saved graph created by the original depth ordered implementation
- an incorrect graph created by our modification breadth ordered implementation
- a corrected graph where we add the "which" keyword to string relations depth first
<img width="1520" alt="image" src="https://user-images.githubusercontent.com/12127/173168312-213934a0-a6c1-4d49-9d0e-56f7030fd71a.png">

